### PR TITLE
añadir regla prefer-const a eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
     "no-trailing-spaces": ["error"],
     "no-var": "error",
     "object-curly-spacing": ["error", "always"],
+    "prefer-const": "error",
     "quotes": ["error", "single"],
     "semi": ["error", "always"],
     "space-before-blocks": "error",


### PR DESCRIPTION
En Javascript const se usa para definir que una variable no cambiará su referencia, es decir que no serán reasignadas posteriormente en el código. `let` debería solo ser usado para definir variables que serán reasignadas en algún momento. 

Al usar `const` en ciertas variables el código será más seguro que tenga menos bugs al obtener un error en el eslint cuando estés reasignando algo definido como const.

Una explicación más en profundidad: https://eslint.org/docs/rules/prefer-const
Mirar también: https://medium.com/tanda-developers/why-do-we-prefer-const-d805b9dc03be